### PR TITLE
Xcode 12.5 Compatibility

### DIFF
--- a/Sources/Combine+Rx/Subject+Rx.swift
+++ b/Sources/Combine+Rx/Subject+Rx.swift
@@ -16,6 +16,7 @@ import RxRelay
 ///
 /// - note: This only works when the underlying Failure is Swift.Error,
 ///         since RxSwift has no typed errors.
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public protocol AnyObserverConvertible: Combine.Subject where Failure == Swift.Error {
     associatedtype Output
 
@@ -25,6 +26,7 @@ public protocol AnyObserverConvertible: Combine.Subject where Failure == Swift.E
     func asAnyObserver() -> AnyObserver<Output>
 }
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public extension AnyObserverConvertible {
     /// Returns a RxSwift AnyObserver wrapping the Subject
     ///
@@ -49,6 +51,7 @@ extension PassthroughSubject: AnyObserverConvertible where Failure == Swift.Erro
 @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension CurrentValueSubject: AnyObserverConvertible where Failure == Swift.Error {}
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public extension ObservableConvertibleType {
     /**
      Creates new subscription and sends elements to a Combine Subject.


### PR DESCRIPTION
Looks like the file `Subject+Rx.swift` was missing some `@available` checks.  This causes the project to fail to compile if the framework's target is < 13.0 (i.e. if you're using CocoaPods and use the generic build target version parameter).

Don't know why Xcode 12.4 doesn't catch this

**Corresponding Issue:** #23 