### PR TITLE
Raise SPM target platform version to satisfy requirements of Combine.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "RxCombine",
     platforms: [
-        .macOS(.v10_10), .iOS(.v9), .tvOS(.v9), .watchOS(.v3)
+        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6)
     ],
     products: [
         .library(


### PR DESCRIPTION
I got build issues when using RxCombine as a third party library in my own project.
<img width="1020" alt="截屏2021-08-22 上午1 07 50" src="https://user-images.githubusercontent.com/8158163/130347147-3c3fc145-3fd7-4fba-b7ec-4e04521b3a48.png">

`canImport(Combine)` directive always yields true when using SDKs bundled with Combine Framework, but actual Combine components subject due to API availability, thus results build issues.

This PR raises SPM target platform version to satisfy requirements of Combine and silents related build errors.