### PR TITLE
Fixed RxSubscription strong reference cycle

### DIFF
--- a/Sources/Rx+Combine/RxSubscription.swift
+++ b/Sources/Rx+Combine/RxSubscription.swift
@@ -19,7 +19,8 @@ class RxSubscription<Upstream: ObservableConvertibleType, Downstream: Subscriber
     init(upstream: Upstream,
          downstream: Downstream) {
         buffer = DemandBuffer(subscriber: downstream)
-        disposable = upstream.asObservable().subscribe(bufferRxEvents)
+        disposable = upstream.asObservable()
+            .subscribe { [unowned self] in self.bufferRxEvents($0) }
     }
 
     private func bufferRxEvents(_ event: RxSwift.Event<Upstream.Element>) {


### PR DESCRIPTION
Passing func of an objec as a closure results in reference to this object in this closure. Saving this closure in the object itself results in strong reference cycle. Object -> Closure -> Object