### PR TITLE
Fix product dependency for RxRelay

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.2
 
 import PackageDescription
 
@@ -10,7 +10,8 @@ let package = Package(
     products: [
         .library(
             name: "RxCombine",
-            targets: ["RxCombine"]),
+            targets: ["RxCombine"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.0.0")
@@ -18,8 +19,12 @@ let package = Package(
     targets: [
         .target(
             name: "RxCombine",
-            dependencies: ["RxSwift", "RxRelay"],
-            path: "Sources"),
+            dependencies: [
+                "RxSwift",
+                .product(name: "RxRelay", package: "RxSwift"),
+            ],
+            path: "Sources"
+        ),
         .testTarget(
             name: "RxCombineTests",
             dependencies: ["RxCombine"],

--- a/RxCombine.podspec
+++ b/RxCombine.podspec
@@ -23,5 +23,5 @@ Pod::Spec.new do |s|
     s.dependency 'RxSwift', '~> 6'
     s.dependency 'RxRelay', '~> 6'
 
-    s.swift_version = '5.1'
+    s.swift_version = '5.2'
   end


### PR DESCRIPTION
In my project I have the following in my `Package.swift`
```swift
    dependencies: [
        .package(url: "https://github.com/ReactiveX/RxSwift.git", "6.0.0"..<"7.0.0"),
        .package(url: "https://github.com/CombineCommunity/RxCombine.git", "2.0.0"..<"3.0.0")
    ],
    targets: [
        .target(
            name: "MyProject",
            dependencies: [
                "RxSwift",
                .product(name: "RxCocoa", package: "RxSwift"),
                "RxCombine",
            ]
        ),
```
This throws the error

> product 'RxRelay' required by package 'rxcombine' target 'RxCombine' not found.

My change fixes that.