### PR TITLE
feat(ci): add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  create_release:
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Carthage archive
+        run: ./scripts/carthage-archive.sh
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: RxCombine ${{ github.ref_name }}
+          files: RxCombine.framework.zip


### PR DESCRIPTION
Adds a workflow that creates a GitHub release upon tag push. This will also run the Carthage archive script and add it to the release.

Rationale: The last couple releases have a missing `RxCombine.framework.zip`, presumably due to some issues with local dev env configuration and running the `carthage-archive.sh` script. By moving this to CI, the environment should be more predictable and consistent.

Also see https://github.com/CombineCommunity/RxCombine/issues/10